### PR TITLE
Added an override that allows for a time stamp to be set whilst logging

### DIFF
--- a/ExtentReports/ExtentReports/ExtentTest.cs
+++ b/ExtentReports/ExtentReports/ExtentTest.cs
@@ -129,10 +129,11 @@ namespace AventStack.ExtentReports
         /// <param name="status"><see cref="Status"/></param>
         /// <param name="details">Log details</param>
         /// <param name="provider">A <see cref="MediaEntityModelProvider"/> object</param>
+        /// <param name="timeStamp">An override to allow for a specific timestamp to be used, rather than the current time</param>
         /// <returns>A <see cref="ExtentTest"/> object</returns>
-        public ExtentTest Log(Status status, string details, MediaEntityModelProvider provider = null)
+        public ExtentTest Log(Status status, string details, MediaEntityModelProvider provider = null, DateTime? timeStamp = null)
         {
-            Log evt = CreateLog(status, details);
+            Log evt = CreateLog(status, details, timeStamp);
 
             if (provider != null)
             {
@@ -189,14 +190,16 @@ namespace AventStack.ExtentReports
             return this;
         }
 
-        private Log CreateLog(Status status, string details = null)
+        private Log CreateLog(Status status, string details = null, DateTime? timeStamp = null)
         {
-            details = details == null ? "" : details.Trim();
+            details = details?.Trim() ?? "";
 
-            Log evt = new Log(this);
-            evt.Status = status;
-            evt.Details = details;
-            evt.Sequence = _test.LogContext().GetAllItems().Count + 1;
+            Log evt = new Log(this, timeStamp)
+            {
+                Status = status,
+                Details = details,
+                Sequence = _test.LogContext().GetAllItems().Count + 1
+            };
 
             return evt;
         }

--- a/ExtentReports/ExtentReports/Model/Log.cs
+++ b/ExtentReports/ExtentReports/Model/Log.cs
@@ -18,17 +18,17 @@ namespace AventStack.ExtentReports.Model
         private ScreenCapture _screenCapture;
         private string _details;
 
-        private Log()
+        private Log(DateTime? timeStamp = null)
         {
-            Timestamp = DateTime.Now;
+            Timestamp = timeStamp ?? DateTime.Now;
         }
 
-        public Log(Test test) : this()
+        public Log(Test test, DateTime? timeStamp = null) : this(timeStamp)
         {
             _parentModel = test;
         }
 
-        public Log(ExtentTest extentTest) : this()
+        public Log(ExtentTest extentTest, DateTime? timeStamp = null) : this(timeStamp)
         {
             _parent = extentTest;
         }


### PR DESCRIPTION
This idea came from wanting to only create a test report if the test fails, so we would store the test details locally then flush them out at the end of the test. This would have the time stamp being inaccurate since datetime.now is always used. This override allows for the time stamp to be stored along side the test details and flushed with it at the end of a test.